### PR TITLE
Using ${^TAINT} to enable taint mode support instead of another varia…

### DIFF
--- a/lib/Devel/Camelcadedb.pm
+++ b/lib/Devel/Camelcadedb.pm
@@ -1828,12 +1828,11 @@ sub _connect
     my $_perl5_debug_host = $ENV{PERL5_DEBUG_HOST};
     my $_perl5_debug_port = $ENV{PERL5_DEBUG_PORT};
 
-    # setting the environment variable 'CAMELCADEDB_TAINT_MODE_SUPPORT' to a
-    # truthy value causes this to untaint the host/port variables, allowing
-    # the debugger to be run on Perl programs that have taint mode enabled.
-    if ($ENV{CAMELCADEDB_TAINT_MODE_SUPPORT})
+    # ${^TAINT} will be truthy if taint mode is on.
+    if (${^TAINT})
     {
-        # untaint the host and port variables
+        # The debugger will fail with "Insecure dependency in connect..."
+        # if we do not untaint the host and port variables, so we do so here.
         ($_perl5_debug_host) = $_perl5_debug_host =~ /(.*)/;
         ($_perl5_debug_port) = $_perl5_debug_port =~ /(.*)/;
     }


### PR DESCRIPTION
…ble.

There seems to be no reason to add an additional CAMELCADEDB_TAINT_MODE_SUPPORT
environment variable to enable taint mode support in the debugger, when
${^TAINT} will let us know that taint mode is on, and any time it *is*
on we'll want to untaint the PERL5_DEBUG_HOST and PERL5_DEBUG_PORT
variables.

This is in reference to issue #29:

https://github.com/Camelcade/Devel-Camelcadedb/issues/29