### PR TITLE
Restore runtime special variables before exit

### DIFF
--- a/lib/Devel/Camelcadedb.pm
+++ b/lib/Devel/Camelcadedb.pm
@@ -968,6 +968,7 @@ sub _get_next_command
         }
         unless ($new_line_index > -1)
         {
+            ( $@, $!, $^E, $,, $/, $\, $^W ) = @saved;
             print STDERR "Buffer $input_buffer has no newlines in it and nothing is in the socket\n";
             exit -1;
         }


### PR DESCRIPTION
When using the debugger with mod_perl2 (Apache httpd) and disconnecting the debug session we often end up in _get_next_command calling "exit -1". This should be fine because mod_perl2 handles this and just terminates the current request. 

The problem is that then the environment variables are not restored and the application starts to behave very strange after that.